### PR TITLE
Wait for read repair before responding

### DIFF
--- a/src/fabric_doc_open_revs.erl
+++ b/src/fabric_doc_open_revs.erl
@@ -162,12 +162,10 @@ is_repair_needed(_, _) ->
 maybe_execute_read_repair(_Db, false) ->
     ok;
 maybe_execute_read_repair(Db, Docs) ->
-    spawn(fun() ->
-        [#doc{id=Id} | _] = Docs,
-        Ctx = #user_ctx{roles=[<<"_admin">>]},
-        Res = fabric:update_docs(Db, Docs, [replicated_changes, {user_ctx,Ctx}]),
-        twig:log(notice, "read_repair ~s ~s ~p", [Db, Id, Res])
-    end).
+    [#doc{id=Id} | _] = Docs,
+    Ctx = #user_ctx{roles=[<<"_admin">>]},
+    Res = fabric:update_docs(Db, Docs, [replicated_changes, {user_ctx,Ctx}]),
+    twig:log(notice, "read_repair ~s ~s ~p", [Db, Id, Res]).
 
 % hackery required so that not_found sorts first
 strip_not_found_missing([]) ->


### PR DESCRIPTION
Our philosophy up to this point has been to respond to the client as soon as possible and execute a repair asynchronously if one was warranted.  This caused occasional problems where a client would receive a 409 Conflict response to an update request based on the Reply that we had just sent if the repair was too slow to execute.

This patch changes the behavior so that in most cases we delay responding to the client until the repair has completed.  The only case where we still respond quickly and issue an asynchronous repair is if we achieved the read quorum and the only alternative replies that we received were ancestors of the quorum reply.

BugzID: 12003
