### PR TITLE
Support stale=update_after

### DIFF
--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -280,7 +280,8 @@ index_of(X, [X|_Rest], I) ->
 index_of(X, [_|Rest], I) ->
     index_of(X, Rest, I+1).
 
-get_shards(DbName, #view_query_args{stale=ok}) ->
+get_shards(DbName, #view_query_args{stale=Stale})
+  when Stale == ok orelse Stale == update_after ->
     mem3:ushards(DbName);
 get_shards(DbName, #view_query_args{stale=false}) ->
     mem3:shards(DbName).


### PR DESCRIPTION
I know this one follows CouchDB's implementation for the single server case, but I'd like to see a version that triggers a view build by simply sending a message to the view group instead of spawning a process to request an updated group.  The process isn't going to do anything with the group, it's just going to sit there taking up resources while the view builds.  Adding a cast handler to the view group should allow us to accept an unlimited number of stale=update_after requests during the lifetime of a build without crashing.
