### PR TITLE
12540 post dup docs

### DIFF
--- a/src/fabric_doc_update.erl
+++ b/src/fabric_doc_update.erl
@@ -25,14 +25,13 @@ go(_, [], _) ->
 go(DbName, AllDocs, Opts) ->
     validate_atomic_update(DbName, AllDocs, lists:member(all_or_nothing, Opts)),
     Options = lists:delete(all_or_nothing, Opts),
-    GroupedDocs = lists:map(fun({#shard{name=Name, node=Node} = Shard, Docs}) ->
-        Ref = rexi:cast(Node, {fabric_rpc, update_docs, [Name, Docs, Options]}),
-        {Shard#shard{ref=Ref}, Docs}
+    GroupedDocs = lists:map(fun({#shard{name=Name, node=Node} = Shard, DocRefs}) ->
+        Ref = rexi:cast(Node, {fabric_rpc, update_docs, [Name, extract_docs(DocRefs), Options]}),
+        {Shard#shard{ref=Ref}, DocRefs}
     end, group_docs_by_shard(DbName, AllDocs)),
     {Workers, _} = lists:unzip(GroupedDocs),
     W = couch_util:get_value(w, Options, couch_config:get("cluster","w","2")),
-    Acc0 = {length(Workers), length(AllDocs), list_to_integer(W), GroupedDocs,
-        dict:from_list([{Doc,[]} || Doc <- AllDocs])},
+    Acc0 = {length(Workers), list_to_integer(W), GroupedDocs, dict:new()},
     case fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0) of
     {ok, Results} ->
         Reordered = reorder_results(AllDocs, Results, []),
@@ -55,18 +54,18 @@ handle_message(internal_server_error, _Worker, Acc0) ->
     % happens when we fail to load validation functions in an RPC worker
     skip_message(Acc0);
 handle_message({ok, Replies}, Worker, Acc0) ->
-    {WaitingCount, DocCount, W, GroupedDocs, DocReplyDict0} = Acc0,
-    Docs = couch_util:get_value(Worker, GroupedDocs),
-    DocReplyDict = append_update_replies(Docs, Replies, DocReplyDict0),
+    {WaitingCount, W, GroupedDocs, ReplyDict} = Acc0,
+    DocRefs = couch_util:get_value(Worker, GroupedDocs),
+    NewReplyDict = append_update_replies(DocRefs, Replies, ReplyDict),
     case WaitingCount of
     1 ->
         % last message has arrived, we need to conclude things
-        {W, Reply} = dict:fold(fun force_reply/3, {W,[]}, DocReplyDict),
+        {W, Reply} = dict:fold(fun force_reply/3, {W,[]}, NewReplyDict),
         {stop, Reply};
     _ ->
-        case dict:fold(fun maybe_reply/3, {stop,W,[]}, DocReplyDict) of
+        case dict:fold(fun maybe_reply/3, {stop, W, []}, NewReplyDict) of
         continue ->
-            {ok, {WaitingCount - 1, DocCount, W, GroupedDocs, DocReplyDict}};
+            {ok, {WaitingCount - 1, W, GroupedDocs, NewReplyDict}};
         {stop, W, FinalReplies} ->
             {stop, FinalReplies}
         end
@@ -74,13 +73,13 @@ handle_message({ok, Replies}, Worker, Acc0) ->
 handle_message({missing_stub, Stub}, _, _) ->
     throw({missing_stub, Stub});
 handle_message({not_found, no_db_file} = X, Worker, Acc0) ->
-    {_, _, _, GroupedDocs, _} = Acc0,
-    Docs = couch_util:get_value(Worker, GroupedDocs),
-    handle_message({ok, [X || _D <- Docs]}, Worker, Acc0).
+    {_, _, GroupedDocs, _} = Acc0,
+    DocRefs = couch_util:get_value(Worker, GroupedDocs),
+    handle_message({ok, [X || _D <- DocRefs]}, Worker, Acc0).
 
-force_reply(Doc, [], {W, Acc}) ->
+force_reply({Doc, _Ref}, [], {W, Acc}) ->
     {W, [{Doc, {error, internal_server_error}} | Acc]};
-force_reply(Doc, [FirstReply|_] = Replies, {W, Acc}) ->
+force_reply({Doc, _Ref}, [FirstReply|_] = Replies, {W, Acc}) ->
     case update_quorum_met(W, Replies) of
     {true, Reply} ->
         {W, lists:foldl(fun(Elem, Acc1) ->
@@ -95,7 +94,7 @@ force_reply(Doc, [FirstReply|_] = Replies, {W, Acc}) ->
 maybe_reply(_, _, continue) ->
     % we didn't meet quorum for all docs, so we're fast-forwarding the fold
     continue;
-maybe_reply(Doc, Replies, {stop, W, Acc}) ->
+maybe_reply({Doc, _Ref}, Replies, {stop, W, Acc}) ->
     case update_quorum_met(W, Replies) of
     {true, Reply} ->
         {stop, W, lists:foldl(fun(Elem, Acc1) ->
@@ -119,23 +118,28 @@ update_quorum_met(W, Replies) ->
 -spec group_docs_by_shard(binary(), [#doc{}]) -> [{#shard{}, [#doc{}]}].
 group_docs_by_shard(DbName, Docs) ->
     dict:to_list(lists:foldl(fun(#doc{id=Id} = Doc, D0) ->
+        % dups may occur, or docs with identical ids
+        % create a reference to differentiate them
+        Ref = make_ref(),
         lists:foldl(fun(Shard, D1) ->
-            dict:append(Shard, Doc, D1)
+            dict:append(Shard, {Doc, Ref}, D1)
         end, D0, mem3:shards(DbName,Id))
     end, dict:new(), Docs)).
 
-append_update_replies([], [], DocReplyDict) ->
-    DocReplyDict;
-append_update_replies([Doc|Rest], [], Dict0) ->
-    % icky, if replicated_changes only errors show up in result
-    append_update_replies(Rest, [], dict:append(Doc, noreply, Dict0));
-append_update_replies([Doc|Rest1], [Reply|Rest2], Dict0) ->
-    % TODO what if the same document shows up twice in one update_docs call?
-    append_update_replies(Rest1, Rest2, dict:append(Doc, Reply, Dict0)).
+extract_docs(DocRefs) ->
+    element(1,lists:unzip(DocRefs)).
 
-skip_message({WaitingCount, _, W, _, DocReplyDict} = Acc0) ->
+
+append_update_replies([], [], ReplyDict) ->
+    ReplyDict;
+append_update_replies([{Doc,Ref} | Rest], [], ReplyDict) ->
+    append_update_replies(Rest, [], dict:append({Doc,Ref}, noreply, ReplyDict));
+append_update_replies([{Doc, Ref}|Rest1], [Reply|Rest2], ReplyDict) ->
+    append_update_replies(Rest1, Rest2, dict:append({Doc,Ref}, Reply, ReplyDict)).
+
+skip_message({WaitingCount, W, _GroupedDocs, ReplyDict} = Acc0) ->
     if WaitingCount =:= 1 ->
-        {W, Reply} = dict:fold(fun force_reply/3, {W,[]}, DocReplyDict),
+        {W, Reply} = dict:fold(fun force_reply/3, {W,[]}, ReplyDict),
         {stop, Reply};
     true ->
         {ok, setelement(1, Acc0, WaitingCount-1)}
@@ -278,7 +282,8 @@ doc_update3_test() ->
 % needed for testing to avoid having to start the mem3 application
 group_docs_by_shard_hack(_DbName, Shards, Docs) ->
     dict:to_list(lists:foldl(fun(#doc{id=_Id} = Doc, D0) ->
+        Ref = make_ref(),
         lists:foldl(fun(Shard, D1) ->
-            dict:append(Shard, Doc, D1)
+            dict:append(Shard, {Doc, Ref}, D1)
         end, D0, Shards)
     end, dict:new(), Docs)).


### PR DESCRIPTION
This fixes the issue with dups in bulk doc requests (COUCHDB-911) Note: this requires a branch from BigCouch of the same name.
