### PR TITLE
make unpack_seqs works with [Seq,Packed] format

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -248,6 +248,9 @@ unpack_seqs(0, DbName) ->
 unpack_seqs("0", DbName) ->
     fabric_dict:init(mem3:shards(DbName), 0);
 
+unpack_seqs([_Seq, Packed], DbName) ->
+    unpack_seqs(Packed, DbName);
+
 unpack_seqs(Packed, DbName) ->
     {match, [Opaque]} = re:run(Packed, "(?<opaque>[a-zA-Z0-9-_]+)([\"\\]])*$",
         [{capture, [opaque], binary}]),


### PR DESCRIPTION
While validate_start_seq/2 works on the since argument passed from HTTP
it doesn't work when you pass it the non encoded sequequence you get
from fabric:changes/4 .

This patch fix it.
