### PR TITLE
Fix callback error handling in fabric:design_docs

### DIFF
--- a/src/fabric.erl
+++ b/src/fabric.erl
@@ -306,7 +306,7 @@ design_docs(DbName) ->
     (complete, Acc) ->
         {ok, lists:reverse(Acc)};
     ({error, Reason}, _Acc) ->
-        {ok, Reason}
+        {error, Reason}
     end,
     fabric:all_docs(dbname(DbName), Callback, [], QueryArgs).
 

--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -31,8 +31,7 @@ remove_down_shards(Collector, BadNode) ->
         {ok, Collector#collector{counters = NewCounters}};
     error ->
         Reason = {nodedown, <<"progress not possible">>},
-        {ok, Resp} = Callback({error, Reason}, Acc),
-        {error, Resp}
+        Callback({error, Reason}, Acc)
     end.
 
 %% @doc looks for a fully covered keyrange in the list of counters


### PR DESCRIPTION
fabric_view:remove_down_shards invokes the callback with an error tuple
and expects an ok response, which it returns as an error to the controller.

BugzID:13065
