### PR TITLE
better handling of update conflicts when nodes down

### DIFF
--- a/src/fabric_doc_update.erl
+++ b/src/fabric_doc_update.erl
@@ -37,6 +37,8 @@ go(DbName, AllDocs, Opts) ->
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0) of
     {ok, {Health, Results}} when Health =:= ok; Health =:= accepted ->
         {Health, [R || R <- couch_util:reorder_results(AllDocs, Results), R =/= noreply]};
+    {ok, {Health, Results}} when Health =:= error ->
+        {ok, [R || R <- couch_util:reorder_results(AllDocs, Results), R =/= noreply]};
     {timeout, Acc} ->
         {_, _, W1, _, DocReplDict} = Acc,
         {Health, _, Resp} = dict:fold(fun force_reply/3, {ok, W1, []},


### PR DESCRIPTION
If a write fails to meet quorum, returning a 202 accept, a subsequent
write of the same doc will return an update conflict but also an error
tuple as nodes could be down. This patch handles that edge case, ensuring
a 409 conflict is returned.

BugzID:13080
