### PR TITLE
fix missed error case in doc update

### DIFF
--- a/src/fabric_doc_update.erl
+++ b/src/fabric_doc_update.erl
@@ -37,8 +37,6 @@ go(DbName, AllDocs, Opts) ->
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0) of
     {ok, {Health, Results}} when Health =:= ok; Health =:= accepted ->
         {Health, [R || R <- couch_util:reorder_results(AllDocs, Results), R =/= noreply]};
-    {ok, {error, Results}} ->
-        {ok, [R || R <- couch_util:reorder_results(AllDocs, Results), R =/= noreply]};
     {timeout, Acc} ->
         {_, _, W1, _, DocReplDict} = Acc,
         {Health, _, Resp} = dict:fold(fun force_reply/3, {ok, W1, []},
@@ -100,8 +98,13 @@ force_reply(Doc, [FirstReply|_] = Replies, {Health, W, Acc}) ->
         twig:log(warn, "write quorum (~p) failed for ~s", [W, Doc#doc.id]),
         case [Reply || {ok, Reply} <- Replies] of
         [] ->
-            % we didn't update any copy, just pick the first error
-            {error, W, [{Doc, FirstReply} | Acc]};
+            % check if all errors are identical, if so inherit health
+            case lists:all(fun(E) -> E =:= FirstReply end, Replies) of
+            true ->
+                {Health, W, [{Doc, FirstReply} | Acc]};
+            false ->
+                {error, W, [{Doc, FirstReply} | Acc]}
+            end;
         [AcceptedRev | _] ->
             NewHealth = case Health of ok -> accepted; _ -> Health end,
             {NewHealth, W, [{Doc, {accepted,AcceptedRev}} | Acc]}


### PR DESCRIPTION
If a write fails to meet quorum, returning a 202 accept, a subsequent
write of the same doc will return an update conflict but also an error
tuple as nodes could be down. This patch handles that edge case, ensuring
a 409 conflict is returned.

BugzID:13080
