### PR TITLE
Fix bad prepend value caused by timeouts

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -129,7 +129,7 @@ receive_results(Workers, State, Timeout, Callback, AccIn) ->
     case rexi_utils:recv(Workers, #shard.ref, fun handle_message/3, State,
             infinity, Timeout) of
     {timeout, NewState0} ->
-        {ok, AccOut} = Callback(timeout, AccIn),
+        {ok, AccOut} = Callback(timeout, NewState0#collector.user_acc),
         NewState = NewState0#collector{user_acc = AccOut},
         receive_results(Workers, NewState, Timeout, Callback, AccOut);
     {_, NewState} ->


### PR DESCRIPTION
When timeouts occur receive_results in fabric_view_changes was using the
original returned response from initial start callback rather than the current
value in the accumulator within the state. Thus it lost the comma needed for
prepending in subsequent calls.

BugzID:13131
