### PR TITLE
Timeout chunked attachment uploads

### DIFF
--- a/src/fabric_doc_attachments.erl
+++ b/src/fabric_doc_attachments.erl
@@ -67,6 +67,8 @@ write_chunks(MiddleMan, ChunkFun) ->
     {MiddleMan, ChunkRecord} ->
         ChunkFun(ChunkRecord, ok),
         write_chunks(MiddleMan, ChunkFun)
+    after 600000 ->
+        exit(timeout)
     end.
 
 receive_unchunked_attachment(_Req, 0) ->


### PR DESCRIPTION
Its possible that the chunked attachment writers would get lost waiting
to receive a message that never arrived. This would end up leaving an
orphaned process that would hold open database shard copies which
prevented them from being freed by delete_nicely.

This patch just inserts a ten minute time limit waiting for the next
message before it gives up and exits. Its important to note that this is
just the length of time between messages carrying data for the
attachment (which should be about 4K each) and not a time limit for the
entire upload.
