### PR TITLE
Add timeout for known length attachment uploads

### DIFF
--- a/src/fabric_doc_attachments.erl
+++ b/src/fabric_doc_attachments.erl
@@ -36,7 +36,11 @@ receiver(Req, Length) when is_integer(Length) ->
     Middleman = spawn(fun() -> middleman(Req, Length) end),
     fun() ->
         Middleman ! {self(), gimme_data},
-        receive {Middleman, Data} -> Data end
+        receive
+            {Middleman, Data} -> Data
+        after 600000 ->
+            exit(timeout)
+        end
     end;
 receiver(_Req, Length) ->
     exit({length_not_integer, Length}).


### PR DESCRIPTION
Similar error condition as fixed earlier today for chunked attachments.
This one seems to happen less often but I did see it while debugging.
