### PR TITLE
Bubble db not found errors

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -314,9 +314,12 @@ wait_db_updated(Timeout) ->
 validate_start_seq(DbName, Seq) ->
     try unpack_seqs(Seq, DbName) of _Any ->
         ok
-    catch _:_ ->
-        Reason = <<"Malformed sequence supplied in 'since' parameter.">>,
-        {error, {bad_request, Reason}}
+    catch
+        error:database_does_not_exist ->
+            {error, database_does_not_exist};
+        _:_ ->
+            Reason = <<"Malformed sequence supplied in 'since' parameter.">>,
+            {error, {bad_request, Reason}}
     end.
 
 unpack_seqs_test() ->


### PR DESCRIPTION
When requesting the _changes feed of a deleted database with a continuous
or longpoll style we would return a `400 Bad Request` error instead of
the correct `404 Not Found`. This was because we were swallowing all
errors when validating the `since` parameter. This patch just catches
the except and returns it appropriately.

BugzId: 13125
