### PR TITLE
Handle nulls that occur in embedded ids

### DIFF
--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -171,6 +171,7 @@ possibly_embed_doc(#collector{db_name=DbName, query_args=Args},
         {Props} = Value,
         Rev0 = couch_util:get_value(<<"_rev">>, Props),
         case couch_util:get_value(<<"_id">>,Props) of
+        null -> Row#view_row{doc=null};
         undefined -> Row;
         IncId ->
             % use separate process to call fabric:open_doc


### PR DESCRIPTION
fabric:docid calls erlang:error if an id is null so it seems like
we should not bother to even spawn a process to call open in this
case as it's a common value from JS errors.

BugzID:13586
