### PR TITLE
Use latest start time as instance_start_time

### DIFF
--- a/src/fabric_db_info.erl
+++ b/src/fabric_db_info.erl
@@ -88,9 +88,11 @@ merge_results(Info) ->
             [{other, {merge_other_results(X)}} | Acc];
         (disk_format_version, X, Acc) ->
             [{disk_format_version, lists:max(X)} | Acc];
+        (instance_start_time, X, Acc) ->
+            [{instance_start_time, lists:max(X)} | Acc];
         (_, _, Acc) ->
             Acc
-    end, [{instance_start_time, <<"0">>}], Dict).
+    end, [], Dict).
 
 merge_other_results(Results) ->
     Dict = lists:foldl(fun({Props}, D) ->


### PR DESCRIPTION
This enables replication tasks to recognize reboots and start over like they should.
