### PR TITLE
15492 fix showroom users cache

### DIFF
--- a/src/fabric_db_update_listener.erl
+++ b/src/fabric_db_update_listener.erl
@@ -103,9 +103,14 @@ stop({Pid, Ref}) ->
     erlang:send(Pid, {Ref, done}).
 
 wait_db_updated({Pid, Ref}) ->
+    MonRef = erlang:monitor(process, Pid),
     erlang:send(Pid, {Ref, get_state}),
     receive
-        {state, Pid, State} -> State
+        {state, Pid, State} ->
+            erlang:demonitor(MonRef, [flush]),
+            State;
+        {'DOWN', MonRef, process, Pid, Reason} ->
+            throw({changes_feed_died, Reason})
     end.
 
 receive_results(Workers, Acc0, Timeout) ->


### PR DESCRIPTION
Make sure that the we report errors when the fabric_db_update_listener process dies. There are two unrelated commits here that should both address the same issue. The first throws an error if recieve_results/3 returns anything other than {ok, Acc}. The second commit also throws an error if we detect that the listener dies without crashing so that we don't end up waiting on an infinite timeout.

To reproduce before this patch:

```
{monitors, [{process, MPid}]} = process_info(whereis(showroom_users_cache), monitors),
{links, [LPid]} = process_info(MPid, links),
LPid ! {rexi_DOWN, nil, {nil, node()}, nil}.
```

I've tested before and after the patch and can show that the patch prevents the update listener from getting wedged in fabric_db_update_lister:wait_db_updated/1 that we found to be at issue in FB 15492.
