### PR TITLE
Omit local docs from read repair operation

### DIFF
--- a/src/fabric_doc_open.erl
+++ b/src/fabric_doc_open.erl
@@ -115,6 +115,9 @@ is_r_met(Workers, Replies, R) ->
 read_repair(#acc{dbname=DbName, replies=Replies}) ->
     Docs = [Doc || {_, {{ok, #doc{}=Doc}, _}} <- Replies],
     case Docs of
+    % omit local docs from read repair
+    [#doc{id = <<?LOCAL_DOC_PREFIX, _/binary>>} | _] ->
+        choose_reply(Docs);
     [#doc{id=Id} | _] ->
         Ctx = #user_ctx{roles=[<<"_admin">>]},
         Opts = [replicated_changes, {user_ctx, Ctx}],


### PR DESCRIPTION
Read repair uses replicated_changes when calling update docs, which does not
distinguish between local and non-local docs.

BugzID: 17527
