### PR TITLE
Disable _changes feed termination by default

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -83,9 +83,12 @@ keep_sending_changes(DbName, Args, Callback, Seqs, AccIn, Timeout, UpListen, T0)
     true ->
         WaitForUpdate = wait_db_updated(UpListen),
         AccumulatedTime = timer:now_diff(os:timestamp(), T0) div 1000,
-        Max = list_to_integer(
-            config:get("fabric", "changes_duration", "300000")
-        ),
+        Max = case config:get("fabric", "changes_duration") of
+        undefined ->
+            infinity;
+        MaxStr ->
+            list_to_integer(MaxStr)
+        end,
         case {Heartbeat, AccumulatedTime > Max, WaitForUpdate} of
         {undefined, _, timeout} ->
             Callback({stop, LastSeq}, AccOut);


### PR DESCRIPTION
This relies on the fact that the atom 'infinity' sorts above all numbers in Erlang.  Of course, so does 'zero', but that'd just be mean.

BugzID: 17682
