### PR TITLE
Send #doc{} instead of #group{} to remote nodes

### DIFF
--- a/src/fabric_view_reduce.erl
+++ b/src/fabric_view_reduce.erl
@@ -31,7 +31,7 @@ go(DbName, DDoc, VName, Args, Callback, Acc0) ->
     {NthRed, View} = fabric_view:extract_view(nil, VName, Views, reduce),
     {VName, RedSrc} = lists:nth(NthRed, View#view.reduce_funs),
     Workers = lists:map(fun(#shard{name=Name, node=N} = Shard) ->
-        Ref = rexi:cast(N, {fabric_rpc, reduce_view, [Name,Group,VName,Args]}),
+        Ref = rexi:cast(N, {fabric_rpc, reduce_view, [Name,DDoc,VName,Args]}),
         Shard#shard{ref = Ref}
     end, fabric_view:get_shards(DbName, Args)),
     RexiMon = fabric_util:create_monitors(Workers),


### PR DESCRIPTION
I realized after the fact that I'm still doing the evil thing of sending records between nodes, so in a later two-phase upgrade we should fix that.  Nevertheless, the RPC workers are now configured to match on the doc record, and this gets us to CommonJS faster.

Should only be deployed on nodes running a 2.4.x version of fabric.

BugzID: 13487
