### PR TITLE
Force abort when rexi_DOWN induces missing range

### DIFF
--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -32,7 +32,7 @@ remove_down_shards(Collector, BadNode) ->
     error ->
         Reason = {nodedown, <<"progress not possible">>},
         Callback({error, Reason}, Acc),
-        {stop, Collector}
+        {error, Reason}
     end.
 
 %% @doc looks for a fully covered keyrange in the list of counters


### PR DESCRIPTION
This prevents the view from returning a partial accumulator.

BugzID: 18735
