### PR TITLE
Index all shards on ddoc update

### DIFF
--- a/src/fabric_db_update_listener.erl
+++ b/src/fabric_db_update_listener.erl
@@ -63,11 +63,12 @@ start_update_notifiers(DbName) ->
 % rexi endpoint
 start_update_notifier(DbNames) ->
     {Caller, Ref} = get(rexi_from),
-    Fun = fun({_, X}) ->
+    Fun = fun({updated, X}) ->
         case lists:member(X, DbNames) of
             true -> erlang:send(Caller, {Ref, db_updated});
             false -> ok
-        end
+        end;
+        (_) -> ok
     end,
     Id = {couch_db_update_notifier, make_ref()},
     ok = gen_event:add_sup_handler(couch_db_update, Id, Fun),


### PR DESCRIPTION
There is a new event message in couch_db_update (`{ddoc_updated, DbName}`). Fabric needs to ignore this event. I talked with Paul and he doesn't think it'd hurt anything to drop all messages other than `{updated, DbName}`. Mostly, it's important for this handler to ignore the `{ddoc_updated, _}` event.
