### PR TITLE
Filter _local docs from the _changes feed

### DIFF
--- a/src/fabric_rpc.erl
+++ b/src/fabric_rpc.erl
@@ -419,6 +419,9 @@ send(Key, Value, #view_acc{limit=Limit} = Acc) ->
         end
     end.
 
+changes_enumerator(#doc_info{id= <<"_local/", _/binary>>, high_seq=Seq},
+        {Db, _OldSeq, Args, Options}) ->
+    {ok, {Db, Seq, Args, Options}};
 changes_enumerator(DocInfo, {Db, _Seq, Args, Options}) ->
     #changes_args{
         include_docs = IncludeDocs,


### PR DESCRIPTION
A bandaid to filter out _local docs that were introduced into the docids
btree due to bugs.
