### PR TITLE
Set middleman timeout to fabric request timeout

### DIFF
--- a/src/fabric_doc_attachments.erl
+++ b/src/fabric_doc_attachments.erl
@@ -103,14 +103,16 @@ middleman(Req, chunked) ->
 
     % take requests from the DB writers and get data from the receiver
     N = erlang:list_to_integer(config:get("cluster","n")),
-    middleman_loop(Receiver, N, [], []);
+    Timeout = fabric_util:request_timeout(),
+    middleman_loop(Receiver, N, [], [], Timeout);
 
 middleman(Req, Length) ->
     Receiver = spawn(fun() -> receive_unchunked_attachment(Req, Length) end),
     N = erlang:list_to_integer(config:get("cluster","n")),
-    middleman_loop(Receiver, N, [], []).
+    Timeout = fabric_util:request_timeout(),
+    middleman_loop(Receiver, N, [], [], Timeout).
 
-middleman_loop(Receiver, N, Counters0, ChunkList0) ->
+middleman_loop(Receiver, N, Counters0, ChunkList0, Timeout) ->
     receive {From, gimme_data} ->
         % Figure out how far along this writer (From) is in the list
         ListIndex = case fabric_dict:lookup_element(From, Counters0) of
@@ -147,7 +149,7 @@ middleman_loop(Receiver, N, Counters0, ChunkList0) ->
             {ChunkList1, Counters1}
         end,
 
-        middleman_loop(Receiver, N, Counters3, ChunkList3)
-    after 10000 ->
+        middleman_loop(Receiver, N, Counters3, ChunkList3, Timeout)
+    after Timeout ->
         ok
     end.


### PR DESCRIPTION
The middleman_loop function in fabric_doc_attachments has a hard coded
ten second timeout. We think this is the cause of ten minute timeouts
seen by some customers. If the RPC workers happent to take more than ten
second to start requesting data (or if they all pause for more than ten
seconds) then the middleman loop dies which triggers the RPC worker
timeout as they wait for attachment data.

This updates the timeout to the fabric per-message timeout which is the
absolute maximum a middleman could go without seeing a message before
the coordinator would exit anyway.
