### PR TITLE
Monitor coordinator pids for update notifiers

### DIFF
--- a/src/fabric_db_update_listener.erl
+++ b/src/fabric_db_update_listener.erl
@@ -72,7 +72,7 @@ start_update_notifier(DbNames) ->
     {Caller, Ref} = get(rexi_from),
     Notify = config:get("cloudant", "maintenance_mode", "false") /= "true",
     State = #cb_state{client_pid = Caller, client_ref = Ref, notify = Notify},
-    Options = [{dbnames, DbNames}],
+    Options = [{parent, Caller}, {dbnames, DbNames}],
     couch_event:listen(?MODULE, handle_db_event, State, Options).
 
 handle_db_event(_DbName, updated, #cb_state{notify = true} = St) ->


### PR DESCRIPTION
We were leaking fabric_db_update_listener rexi workers. This uses the
new couch_event configurability to have the workers automatically exit
when the coordinator dies.
