### PR TITLE
Gracefully terminate continuous changes feeds

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -79,7 +79,8 @@ keep_sending_changes(DbName, Args, Callback, Seqs, AccIn, Timeout, UpListen, T0)
     #collector{limit=Limit2, counters=NewSeqs, user_acc=AccOut} = Collector,
     LastSeq = pack_seqs(NewSeqs),
     MaintenanceMode = config:get("cloudant", "maintenance_mode"),
-    if Limit > Limit2, Feed == "longpoll"; MaintenanceMode == "true" ->
+    if Limit > Limit2, Feed == "longpoll";
+       MaintenanceMode == "true"; MaintenanceMode == "nolb" ->
         Callback({stop, LastSeq}, AccOut);
     true ->
         WaitForUpdate = wait_db_updated(UpListen),


### PR DESCRIPTION
When maintenance_mode is set to "true", end all active continuous
changes feeds gracefully with a last_seq chunk and clean TCP
termination.
