### PR TITLE
Gracefully terminate continuous changes feeds

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -78,7 +78,9 @@ keep_sending_changes(DbName, Args, Callback, Seqs, AccIn, Timeout, UpListen, T0)
     {ok, Collector} = send_changes(DbName, Args, Callback, Seqs, AccIn, Timeout),
     #collector{limit=Limit2, counters=NewSeqs, user_acc=AccOut} = Collector,
     LastSeq = pack_seqs(NewSeqs),
-    if Limit > Limit2, Feed == "longpoll" ->
+    MaintenanceMode = config:get("cloudant", "maintenance_mode"),
+    if Limit > Limit2, Feed == "longpoll";
+      MaintenanceMode == "true"; MaintenanceMode == "nolb" ->
         Callback({stop, LastSeq}, AccOut);
     true ->
         WaitForUpdate = wait_db_updated(UpListen),


### PR DESCRIPTION
When maintenance_mode is set to "true" or "nolb", end all active continuous
changes feeds gracefully with a last_seq chunk and clean TCP
termination.

BugzID: 21618
