### PR TITLE
Fix changes shard replacement

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -363,7 +363,8 @@ do_unpack_seqs(Opaque, DbName) ->
         true ->
             Unpacked;
         false ->
-            Ranges = lists:usort([R || #shard{range=R} <- Unpacked]),
+            Extract = fun({Shard, _Seq}) -> Shard#shard.range end,
+            Ranges = lists:usort(lists:map(Extract, Unpacked)),
             Filter = fun(S) -> not lists:member(S#shard.range, Ranges) end,
             Replacements = lists:filter(Filter, mem3:shards(DbName)),
             Unpacked ++ [{R, 0} || R <- Replacements]


### PR DESCRIPTION
We were unwittingly falling victim to list comprehensions swallowing
exceptions again. The result this time was that anytime we needed to
replace a changes shard we were adding the entire shard map. This means
that any time we were resetting the feed its possible we could have
reset the feed for all shard ranges depending on the rexi worker race.

BugzId: 22808
