### PR TITLE
Fix hot upgrade for new since values

### DIFF
--- a/src/fabric_rpc.erl
+++ b/src/fabric_rpc.erl
@@ -450,13 +450,14 @@ changes_enumerator(DocInfo, {Db, _Seq, Args, Options}) ->
         {Go, {Db, Seq, Args, Options}}
     end.
 
+% TODO change to {Seq, uuid(Db)}
 changes_row(Db, #doc_info{id=Id, high_seq=Seq}=DI, Results, Del, true, Opts) ->
     Doc = doc_member(Db, DI, Opts),
-    #change{key={Seq, uuid(Db)}, id=Id, value=Results, doc=Doc, deleted=Del};
+    #change{key={Seq, uuid(Db), []}, id=Id, value=Results, doc=Doc, deleted=Del};
 changes_row(Db, #doc_info{id=Id, high_seq=Seq}, Results, true, _, _) ->
-    #change{key={Seq, uuid(Db)}, id=Id, value=Results, deleted=true};
+    #change{key={Seq, uuid(Db), []}, id=Id, value=Results, deleted=true};
 changes_row(Db, #doc_info{id=Id, high_seq=Seq}, Results, _, _, _) ->
-    #change{key={Seq, uuid(Db)}, id=Id, value=Results}.
+    #change{key={Seq, uuid(Db), []}, id=Id, value=Results}.
 
 doc_member(Shard, DocInfo, Opts) ->
     case couch_db:open_doc(Shard, DocInfo, [deleted | Opts]) of
@@ -540,6 +541,8 @@ set_io_priority(DbName, Options) ->
 
 calculate_start_seq(_Db, _Node, Seq) when is_integer(Seq) ->
     Seq;
+calculate_start_seq(Db, Node, {Seq, Uuid, _}) -> % remove me
+    calculate_start_seq(Db, Node, {Seq, Uuid});
 calculate_start_seq(Db, Node, {Seq, Uuid}) ->
     case is_prefix(Uuid, couch_db:get_uuid(Db)) of
         true ->

--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -298,6 +298,7 @@ pack_seqs(Workers) ->
     Opaque = couch_util:encodeBase64Url(term_to_binary(SeqList, [compressed])),
     [SeqSum, Opaque].
 
+seq({Seq, _Uuid, _Node}) -> Seq; % remove me
 seq({Seq, _Uuid}) -> Seq;
 seq(Seq)          -> Seq.
 


### PR DESCRIPTION
Continuous changes feeds never move to the new version of fabric_view_changes, instead endlessly looping between keep_sending_changes and pack_seqs (among others). As a consequence, the new since value format of {Seq, Uuid} was being passed directly to lists:sum, and crashing.

This patch (largely by @davisp) co-opts a previous deployment that included an anticipatory change for this upgrade which expects a 3-tuple. To trick the system into upgrading smoothly, we send an ignored third term (the empty list, which encodes to a single byte) to be removed in a future release.

This has been SO much fun.
