### PR TITLE
Allow to omit seq from some rows in _changes response

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -201,7 +201,13 @@ handle_message(#change{key=Key} = Row0, {Worker, From}, St) ->
         % created from DOWN messages would have led to errors
         case fabric_view:is_progress_possible(S2) of
         true ->
-            Row = Row0#change{key = pack_seqs(S2)},
+            % Temporary hack for FB 23637
+            Interval = erlang:get(changes_seq_interval),
+            if (Interval == undefined) orelse (Limit rem Interval == 0) ->
+                Row = Row0#change{key = pack_seqs(S2)};
+            true ->
+                Row = Row0#change{key = null}
+            end,
             {Go, Acc} = Callback(changes_row(Row, IncludeDocs), AccIn),
             gen_server:reply(From, Go),
             {Go, St#collector{counters=S2, limit=Limit-1, user_acc=Acc}};


### PR DESCRIPTION
This is a hack to improve the throughput of _changes on databases with large Q values.  The record-based approach for sharing config options is a pain to extend so we're going to be dirty and use the pdict here.

BugzID: 23637
