### PR TITLE
Fix the write quorum failed log message

### DIFF
--- a/src/fabric_doc_update.erl
+++ b/src/fabric_doc_update.erl
@@ -114,17 +114,22 @@ force_reply(Doc, [FirstReply|_] = Replies, {Health, W, Acc}) ->
     {true, Reply} ->
         {Health, W, [{Doc,Reply} | Acc]};
     false ->
-        twig:log(warn, "write quorum (~p) failed for ~s", [W, Doc#doc.id]),
         case [Reply || {ok, Reply} <- Replies] of
         [] ->
             % check if all errors are identical, if so inherit health
             case lists:all(fun(E) -> E =:= FirstReply end, Replies) of
             true ->
+                CounterKey = [fabric, doc_update, errors],
+                margaret_counter:increment(CounterKey),
                 {Health, W, [{Doc, FirstReply} | Acc]};
             false ->
+                CounterKey = [fabric, doc_update, mismatched_errors],
+                margaret_counter:increment(CounterKey),
                 {error, W, [{Doc, FirstReply} | Acc]}
             end;
         [AcceptedRev | _] ->
+            CounterKey = [fabric, doc_update, write_quorum_errors],
+            margaret_counter:increment(CounterKey),
             NewHealth = case Health of ok -> accepted; _ -> Health end,
             {NewHealth, W, [{Doc, {accepted,AcceptedRev}} | Acc]}
         end


### PR DESCRIPTION
We only accept a write in some specific circumstances. Ever conflic
would trigger this log message. We only want to send a log message when
we have inconsistency in our replies. Three `conflict` replies should no
trigger the log message.
