### PR TITLE
Cleanup workers even if they didn't contribute

### DIFF
--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -50,7 +50,8 @@ submit_jobs(Shards, Module, EndPoint, ExtraArgs) ->
         Shard#shard{ref = Ref}
     end, Shards).
 
-cleanup(Workers) ->
+cleanup(Workers0) ->
+    Workers = lists:ukeysort(#shard.ref, Workers0),
     [rexi:kill(Node, Ref) || #shard{node=Node, ref=Ref} <- Workers].
 
 stream_start(Workers, Keypos) ->

--- a/src/fabric_view_all_docs.erl
+++ b/src/fabric_view_all_docs.erl
@@ -32,7 +32,7 @@ go(DbName, #view_query_args{keys=nil} = QueryArgs, Callback, Acc) ->
                 try
                     go(DbName, Workers, QueryArgs, Callback, Acc)
                 after
-                    fabric_util:cleanup(Workers)
+                    fabric_util:cleanup(Workers0 ++ Workers)
                 end;
             {timeout, _} ->
                 Callback({error, timeout}, Acc);

--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -152,7 +152,7 @@ send_changes(DbName, ChangesArgs, Callback, PackedSeqs, AccIn, Timeout) ->
                     send_changes(DbName, Workers, LiveSeqs, ChangesArgs,
                             Callback, AccIn, Timeout)
                 after
-                    fabric_util:cleanup(Workers)
+                    fabric_util:cleanup(Workers0 ++ Workers)
                 end;
             Else ->
                 Callback(Else, AccIn)

--- a/src/fabric_view_map.erl
+++ b/src/fabric_view_map.erl
@@ -39,7 +39,7 @@ go(DbName, DDoc, View, Args, Callback, Acc) ->
                 try
                     go(DbName, Workers, Args, Callback, Acc)
                 after
-                    fabric_util:cleanup(Workers)
+                    fabric_util:cleanup(Workers0 ++ Workers)
                 end;
             {timeout, _} ->
                 Callback({error, timeout}, Acc);

--- a/src/fabric_view_reduce.erl
+++ b/src/fabric_view_reduce.erl
@@ -44,7 +44,7 @@ go(DbName, DDoc, VName, Args, Callback, Acc) ->
                 try
                     go(DbName, Workers, Lang, RedSrc, Args, Callback, Acc)
                 after
-                    fabric_util:cleanup(Workers)
+                    fabric_util:cleanup(Workers0 ++ Workers)
                 end;
             {timeout, _} ->
                 Callback({error, timeout}, Acc);


### PR DESCRIPTION
This avoids the possibility that a worker initializes a stream late and eventually times out.

It's a more heavyweight and more complete alternative / complement to cloudant/rexi#19

BugzID: 24507
