### PR TITLE
Report errors opening documents during _all_docs

### DIFF
--- a/src/fabric_view_all_docs.erl
+++ b/src/fabric_view_all_docs.erl
@@ -201,7 +201,18 @@ doc_receive_loop(Keys, Pids, SpawnFun, MaxJobs, Callback, AccIn) ->
         end
     end.
 
+
 open_doc(DbName, Id, IncludeDocs) ->
+    try
+        open_doc_int(DbName, Id, IncludeDocs)
+    catch Type:Reason ->
+        Stack = erlang:get_stacktrace(),
+        twig:log(err, "_all_docs open error: ~s ~s :: ~w ~w", [
+                DbName, Id, {Type, Reason}, Stack]),
+        exit({Id, Reason})
+    end.
+
+open_doc_int(DbName, Id, IncludeDocs) ->
     Row = case fabric:open_doc(DbName, Id, [deleted]) of
     {not_found, missing} ->
         Doc = undefined,


### PR DESCRIPTION
All errors are currently ignored in the receive statements and eventually we timeout.  This patch causes fabric to report the error and terminate quickly instead of waiting.

BugzID: 24580
