### PR TITLE
Throw errors when starting changes streams

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -176,8 +176,10 @@ send_changes(DbName, ChangesArgs, Callback, PackedSeqs, AccIn, Timeout) ->
                 after
                     fabric_util:cleanup(Workers)
                 end;
+            {error, Reason} ->
+                throw({error, Reason});
             Else ->
-                Callback(Else, AccIn)
+                throw({error, Else})
         end
     after
         rexi_monitor:stop(RexiMon)


### PR DESCRIPTION
Previously we were calling the user supplied callback on these errors
which caused a badmatch in keep_sending_changes. This just throws the
error and lets chttpd handle formatting it for the user.

BugzId: 26122
