### PR TITLE
Don't attempt to replace replacement shards

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -138,10 +138,10 @@ send_changes(DbName, ChangesArgs, Callback, PackedSeqs, AccIn, Timeout) ->
     StartFun = fun(#shard{name=Name, node=N, range=R0}=Shard) ->
         %% Find the original shard copy in the Seqs array
         case lists:dropwhile(fun({S, _}) -> S#shard.range =/= R0 end, Seqs) of
-            % The {_, _}=OldSeq pattern match is so that we don't
-            % accidentally try and replace based on the generated
-            % {replace, _, _, _} tuples.
-            [{#shard{node = OldNode}, {_, _}=OldSeq} | _] ->
+            [{#shard{}, {replace, _, _, _}} | _] ->
+                % Don't attempt to replace a replacement
+                SeqArg = 0;
+            [{#shard{node = OldNode}, OldSeq} | _] ->
                 SeqArg = make_replacement_arg(OldNode, OldSeq);
             _ ->
                 % TODO this clause is probably unreachable in the N>2


### PR DESCRIPTION
The old test was looking for {_, _} tuple but that doesn't account for
old since sequences. This just switches to using a negative selection.
The only bad behavior was that we were making lots of log messages about
rewinding from 0 in known conditions.

BugzId: 26125
