### PR TITLE
Make _changes?descending=true aware of maint. mode

### DIFF
--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -331,27 +331,8 @@ make_changes_args(Args) ->
 get_start_seq(_DbName, #changes_args{dir=fwd, since=Since}) ->
     Since;
 get_start_seq(DbName, #changes_args{dir=rev}) ->
-    Shards = mem3:shards(DbName),
-    Workers = fabric_util:submit_jobs(Shards, get_update_seq, []),
-    {ok, Since} = fabric_util:recv(Workers, #shard.ref,
-        fun collect_update_seqs/3, fabric_dict:init(Workers, -1)),
-    Since.
-
-collect_update_seqs(Seq, Shard, Counters) when is_integer(Seq) ->
-    case fabric_dict:lookup_element(Shard, Counters) of
-    undefined ->
-        % already heard from someone else in this range
-        {ok, Counters};
-    -1 ->
-        C1 = fabric_dict:store(Shard, Seq, Counters),
-        C2 = fabric_view:remove_overlapping_shards(Shard, C1),
-        case fabric_dict:any(-1, C2) of
-        true ->
-            {ok, C2};
-        false ->
-            {stop, pack_seqs(C2)}
-        end
-    end.
+    {ok, Info} = fabric:get_db_info(DbName),
+    couch_util:get_value(update_seq, Info).
 
 pending_count(Dict) ->
     fabric_dict:fold(fun


### PR DESCRIPTION
The `_changes` coordinator was using a one-off thing to get the start sequence for a database which did not provide any error handling at all. This patch replaces that one-off with a call to `get_db_info/1`, which does include all the normal error handling.

A future enhancement could teach the coordinator to understand a "sequence" like `eof` that would cause all the workers to automatically seek to the end, but I wanted to stay conservative here in order to land this for the next release.

BugzID: 25944
