### PR TITLE
Report new data size entries in info blobs

### DIFF
--- a/src/fabric_db_info.erl
+++ b/src/fabric_db_info.erl
@@ -100,6 +100,8 @@ merge_results(Info) ->
             [{disk_size, lists:sum(X)} | Acc];
         (other, X, Acc) ->
             [{other, {merge_other_results(X)}} | Acc];
+        (sizes, X, Acc) ->
+            [{sizes, {fabric_util:merge_size_objects(X)}} | Acc];
         (disk_format_version, X, Acc) ->
             [{disk_format_version, lists:max(X)} | Acc];
         (_, _, Acc) ->

--- a/src/fabric_group_info.erl
+++ b/src/fabric_group_info.erl
@@ -88,6 +88,8 @@ merge_results(Info) ->
             [{disk_size, lists:sum(X)} | Acc];
         (data_size, X, Acc) ->
             [{data_size, lists:sum(X)} | Acc];
+        (sizes, X, Acc) ->
+            [{sizes, {fabric_util:merge_size_objects(X)}} | Acc];
         (compact_running, X, Acc) ->
             [{compact_running, lists:member(true, X)} | Acc];
         (updater_running, X, Acc) ->


### PR DESCRIPTION
This consolidates all of the file size information under a single key in
the info JSON. The previous entries for disk_size and data_size are left
untouched for backwards compatibility.

BugzId: 27061
