### PR TITLE
Call set_io_priority/2 before fetching design documents

### DIFF
--- a/src/fabric_rpc2.erl
+++ b/src/fabric_rpc2.erl
@@ -129,6 +129,7 @@ map_view(DbName, DDocInfo, ViewName, QueryArgs) ->
     map_view(DbName, DDocInfo, ViewName, QueryArgs, []).
 
 map_view(DbName, {DDocId, Rev}, ViewName, QueryArgs, DbOptions) ->
+    set_io_priority(DbName, DbOptions),
     {ok, DDoc} = ddoc_cache:open_doc(mem3:dbname(DbName), DDocId, Rev),
     map_view(DbName, DDoc, ViewName, QueryArgs, DbOptions);
 map_view(DbName, DDoc, ViewName, QueryArgs, DbOptions) ->
@@ -177,9 +178,11 @@ reduce_view(DbName, DDocInfo, ViewName, QueryArgs) ->
     reduce_view(DbName, DDocInfo, ViewName, QueryArgs, []).
 
 reduce_view(DbName, {DDocId, Rev}, ViewName, QueryArgs, DbOptions) ->
+    set_io_priority(DbName, DbOptions),
     {ok, DDoc} = ddoc_cache:open_doc(mem3:dbname(DbName), DDocId, Rev),
     reduce_view(DbName, DDoc, ViewName, QueryArgs, DbOptions);
 reduce_view(DbName, #doc{}=DDoc, ViewName, QueryArgs, DbOptions) ->
+    set_io_priority(DbName, DbOptions),
     Group = couch_view_group:design_doc_to_view_group(DDoc),
     reduce_view(DbName, Group, ViewName, QueryArgs, DbOptions);
 reduce_view(DbName, Group0, ViewName, QueryArgs, DbOptions) ->


### PR DESCRIPTION
This change causes nodes that are in maintenance mode to drop view
requests earlier than they would otherwise. Without it, calls to
ddoc_cache:open_doc/3 are being made on nodes that are in maintenance
mode, with what appears to be undesirable results.

BugzID: 27483
