### PR TITLE
Fix fabric_db_update_listener code upgrades

### DIFF
--- a/src/fabric_db_update_listener.erl
+++ b/src/fabric_db_update_listener.erl
@@ -117,6 +117,8 @@ wait_db_updated({Pid, Ref}) ->
             State;
         {'DOWN', MonRef, process, Pid, Reason} ->
             throw({changes_feed_died, Reason})
+    after 300000 ->
+        ?MODULE:wait_db_updated({Pid, Ref})
     end.
 
 receive_results(Workers, Acc0, Timeout) ->


### PR DESCRIPTION
Changes procesess waiting idle for db update messages will never upgrade
their code. This just adds a timeout before recursing through the module
exports table to load new code.

BugzId: 27660
