### PR TITLE
Indicate when read quorums are met

### DIFF
--- a/src/fabric_doc_open.erl
+++ b/src/fabric_doc_open.erl
@@ -48,7 +48,7 @@ go(DbName, Id, Options) ->
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0) of
     {ok, #acc{}=Acc} ->
         Reply = handle_response(Acc),
-        format_reply(Reply, SuppressDeletedDoc);
+        format_reply(Reply, SuppressDeletedDoc, Acc#acc.state);
     Error ->
         Error
     after
@@ -155,6 +155,14 @@ choose_reply(Docs) ->
         InfoA > InfoB
     end, Docs),
     {ok, Winner}.
+
+
+format_reply({ok, Doc}, SupressDeleted, r_not_met) ->
+    NewMeta = [r_not_met | Doc#doc.meta],
+    format_reply({ok, Doc#doc{meta=NewMeta}}, SupressDeleted);
+format_reply(Else, SupressDeleted, _) ->
+    format_reply(Else, SupressDeleted).
+
 
 format_reply({ok, #doc{deleted=true}}, true) ->
     {not_found, deleted};


### PR DESCRIPTION
Currently there is no indication if a read operation has met the
requested quorum level. This patch and a corresponding patch to dbcore
enable this indication by adding a special document member `_r_met` that
is set to false when quorum is not met. When the requested quorum is met
the field does not exist. This is to ensure no changes for normal use
cases.

Unfortunately this change breaks replication to any node or cluster that
doesn't have these patches. I don't really expect this to be merged as
is but the tests were so pretty I couldn't help but finish it off.

BugzId: 26369
