### PR TITLE
Consistently log fabric worker timeouts

### DIFF
--- a/include/fabric.hrl
+++ b/include/fabric.hrl
@@ -34,5 +34,11 @@
     user_acc
 }).
 
+-record(stream_acc, {
+    workers,
+    start_fun,
+    replacements
+}).
+
 -record(view_row, {key, id, value, doc, worker}).
 -record(change, {key, id, value, deleted=false, doc, worker}).

--- a/src/fabric_db_create.erl
+++ b/src/fabric_db_create.erl
@@ -75,6 +75,9 @@ create_shard_files(Shards) ->
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Workers) of
     {error, file_exists} ->
         file_exists;
+    {timeout, DefunctWorkers} ->
+        fabric_util:log_timeout(DefunctWorkers, "create_db"),
+        {error, timeout};
     _ ->
         ok
     after
@@ -106,7 +109,12 @@ create_shard_db_doc(Doc) ->
     Workers = fabric_util:submit_jobs(Shards, create_shard_db_doc, [Doc]),
     Acc0 = {length(Shards), fabric_dict:init(Workers, nil)},
     try fabric_util:recv(Workers, #shard.ref, fun handle_db_update/3, Acc0) of
-    {timeout, _} ->
+    {timeout, {_, WorkersDict}} ->
+        DefunctWorkers = fabric_util:remove_done_workers(WorkersDict, nil),
+        fabric_util:log_timeout(
+            DefunctWorkers,
+            "create_shard_db_doc"
+        ),
         {error, timeout};
     Else ->
         Else

--- a/src/fabric_db_delete.erl
+++ b/src/fabric_db_delete.erl
@@ -45,7 +45,12 @@ delete_shard_db_doc(Doc) ->
     Workers = fabric_util:submit_jobs(Shards, delete_shard_db_doc, [Doc]),
     Acc0 = {length(Shards), fabric_dict:init(Workers, nil)},
     try fabric_util:recv(Workers, #shard.ref, fun handle_db_update/3, Acc0) of
-    {timeout, _} ->
+    {timeout, {_, WorkersDict}} ->
+        DefunctWorkers = fabric_util:remove_done_workers(WorkersDict, nil),
+        fabric_util:log_timeout(
+            DefunctWorkers,
+            "delete_shard_db_doc"
+        ),
         {error, timeout};
     Else ->
         Else

--- a/src/fabric_db_doc_count.erl
+++ b/src/fabric_db_doc_count.erl
@@ -25,8 +25,13 @@ go(DbName) ->
     Workers = fabric_util:submit_jobs(Shards, get_doc_count, []),
     RexiMon = fabric_util:create_monitors(Shards),
     Acc0 = {fabric_dict:init(Workers, nil), 0},
-    try
-        fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0)
+    try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0) of
+    {timeout, {WorkersDict, _}} ->
+        DefunctWorkers = fabric_util:remove_done_workers(WorkersDict, nil),
+        fabric_util:log_timeout(DefunctWorkers, "get_doc_count"),
+        {error, timeout};
+    Else ->
+        Else
     after
         rexi_monitor:stop(RexiMon)
     end.

--- a/src/fabric_db_info.erl
+++ b/src/fabric_db_info.erl
@@ -28,6 +28,16 @@ go(DbName) ->
     try
         case fabric_util:recv(Workers, #shard.ref, Fun, Acc0) of
             {ok, Acc} -> {ok, Acc};
+            {timeout, {WorkersDict, _}} ->
+                DefunctWorkers = fabric_util:remove_done_workers(
+                    WorkersDict,
+                    nil
+                ),
+                fabric_util:log_timeout(
+                    DefunctWorkers,
+                    "get_db_info"
+                ),
+                {error, timeout};
             {error, Error} -> throw(Error)
         end
     after

--- a/src/fabric_db_meta.erl
+++ b/src/fabric_db_meta.erl
@@ -31,19 +31,22 @@ set_revs_limit(DbName, Limit, Options) ->
     Shards = mem3:shards(DbName),
     Workers = fabric_util:submit_jobs(Shards, set_revs_limit, [Limit, Options]),
     Handler = fun handle_revs_message/3,
-    Waiting = length(Workers) - 1,
-    case fabric_util:recv(Workers, #shard.ref, Handler, Waiting) of
+    Acc0 = {Workers, length(Workers) - 1},
+    case fabric_util:recv(Workers, #shard.ref, Handler, Acc0) of
     {ok, ok} ->
         ok;
+    {timeout, {DefunctWorkers, _}} ->
+        fabric_util:log_timeout(DefunctWorkers, "set_revs_limit"),
+        {error, timeout};
     Error ->
         Error
     end.
 
-handle_revs_message(ok, _, 0) ->
+handle_revs_message(ok, _, {_Workers, 0}) ->
     {stop, ok};
-handle_revs_message(ok, _, Waiting) ->
-    {ok, Waiting - 1};
-handle_revs_message(Error, _, _Waiting) ->
+handle_revs_message(ok, Worker, {Workers, Waiting}) ->
+    {ok, {lists:delete(Worker, Workers), Waiting - 1}};
+handle_revs_message(Error, _, _Acc) ->
     {error, Error}.
 
 
@@ -63,6 +66,9 @@ set_security(DbName, SecObj, Options) ->
             ok -> ok;
             Error -> Error
         end;
+    {timeout, #acc{workers=DefunctWorkers}} ->
+        fabric_util:log_timeout(DefunctWorkers, "set_security"),
+        {error, timeout};
     Error ->
         Error
     after
@@ -135,6 +141,12 @@ get_all_security(DbName, Options) ->
         {ok, SecObjs};
     {ok, _} ->
         {error, no_majority};
+    {timeout, #acc{workers=DefunctWorkers}} ->
+        fabric_util:log_timeout(
+            DefunctWorkers,
+            "get_all_security"
+        ),
+        {error, timeout};
     Error ->
         Error
     after

--- a/src/fabric_dict.erl
+++ b/src/fabric_dict.erl
@@ -54,3 +54,6 @@ filter(Fun, Dict) ->
 
 fold(Fun, Acc0, Dict) ->
     orddict:fold(Fun, Acc0, Dict).
+
+to_list(Dict) ->
+    orddict:to_list(Dict).

--- a/src/fabric_doc_missing_revs.erl
+++ b/src/fabric_doc_missing_revs.erl
@@ -31,8 +31,15 @@ go(DbName, AllIdsRevs, Options) ->
     ResultDict = dict:from_list([{Id, {{nil,Revs},[]}} || {Id, Revs} <- AllIdsRevs]),
     RexiMon = fabric_util:create_monitors(Workers),
     Acc0 = {length(Workers), ResultDict, Workers},
-    try
-        fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0)
+    try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0) of
+    {timeout, {_, _, DefunctWorkers}} ->
+        fabric_util:log_timeout(
+            DefunctWorkers,
+            "get_missing_revs"
+        ),
+        {error, timeout};
+    Else ->
+        Else
     after
         rexi_monitor:stop(RexiMon)
     end.

--- a/src/fabric_doc_open.erl
+++ b/src/fabric_doc_open.erl
@@ -49,6 +49,9 @@ go(DbName, Id, Options) ->
     {ok, #acc{}=Acc} ->
         Reply = handle_response(Acc),
         format_reply(Reply, SuppressDeletedDoc);
+    {timeout, #acc{workers=DefunctWorkers}} ->
+        fabric_util:log_timeout(DefunctWorkers, "open_doc"),
+        {error, timeout};
     Error ->
         Error
     after

--- a/src/fabric_doc_open_revs.erl
+++ b/src/fabric_doc_open_revs.erl
@@ -49,6 +49,9 @@ go(DbName, Id, Revs, Options) ->
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, State) of
     {ok, {ok, Reply}} ->
         {ok, Reply};
+    {timeout, #state{workers=DefunctWorkers}} ->
+        fabric_util:log_timeout(DefunctWorkers, "open_revs"),
+        {error, timeout};
     Else ->
         Else
     after

--- a/src/fabric_doc_update.erl
+++ b/src/fabric_doc_update.erl
@@ -41,7 +41,9 @@ go(DbName, AllDocs0, Opts) ->
     {ok, {Health, Results}} when Health =:= ok; Health =:= accepted ->
         {Health, [R || R <- couch_util:reorder_results(AllDocs, Results), R =/= noreply]};
     {timeout, Acc} ->
-        {_, _, W1, _, DocReplDict} = Acc,
+        {_, _, W1, GroupedDocs1, DocReplDict} = Acc,
+        {DefunctWorkers, _} = lists:unzip(GroupedDocs1),
+        fabric_util:log_timeout(DefunctWorkers, "update_docs"),
         {Health, _, Resp} = dict:fold(fun force_reply/3, {ok, W1, []},
             DocReplDict),
         {Health, [R || R <- couch_util:reorder_results(AllDocs, Resp), R =/= noreply]};

--- a/src/fabric_group_info.erl
+++ b/src/fabric_group_info.erl
@@ -30,8 +30,13 @@ go(DbName, #doc{} = DDoc) ->
     Workers = fabric_util:submit_jobs(Shards, group_info, [Group]),
     RexiMon = fabric_util:create_monitors(Shards),
     Acc0 = {fabric_dict:init(Workers, nil), []},
-    try
-        fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0)
+    try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0) of
+    {timeout, {WorkersDict, _}} ->
+        DefunctWorkers = fabric_util:remove_done_workers(WorkersDict, nil),
+        fabric_util:log_timeout(DefunctWorkers, "group_info"),
+        {error, timeout};
+    Else ->
+        Else
     after
         rexi_monitor:stop(RexiMon)
     end.

--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -19,6 +19,7 @@
         remove_down_workers/2, doc_id_and_rev/1]).
 -export([request_timeout/0, attachments_timeout/0, all_docs_timeout/0]).
 -export([stream_start/2, stream_start/4]).
+-export([log_timeout/2, remove_done_workers/2]).
 
 -compile({inline, [{doc_id_and_rev,1}]}).
 
@@ -26,12 +27,6 @@
 -include_lib("mem3/include/mem3.hrl").
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("eunit/include/eunit.hrl").
-
--record(stream_acc, {
-    workers,
-    start_fun,
-    replacements
-}).
 
 remove_down_workers(Workers, BadNode) ->
     Filter = fun(#shard{node = Node}, _) -> Node =/= BadNode end,
@@ -156,6 +151,15 @@ timeout(Type, Default) ->
         "infinity" -> infinity;
         N -> list_to_integer(N)
     end.
+
+log_timeout(Workers, EndPoint) ->
+    lists:map(fun(#shard{node=Dest, name=Name}) ->
+        Fmt = "fabric_worker_timeout ~s,~p,~p",
+        ?LOG_ERROR(Fmt, [EndPoint, Dest, Name])
+    end, Workers).
+
+remove_done_workers(Workers, WaitingIndicator) ->
+    [W || {W, WI} <- fabric_dict:to_list(Workers), WI == WaitingIndicator].
 
 get_db(DbName) ->
     get_db(DbName, []).

--- a/src/fabric_view_all_docs.erl
+++ b/src/fabric_view_all_docs.erl
@@ -34,7 +34,14 @@ go(DbName, #view_query_args{keys=nil} = QueryArgs, Callback, Acc) ->
                 after
                     fabric_util:cleanup(Workers)
                 end;
-            {timeout, _} ->
+            {timeout, NewState} ->
+                DefunctWorkers = fabric_util:remove_done_workers(
+                    NewState#stream_acc.workers, waiting
+                ),
+                fabric_util:log_timeout(
+                    DefunctWorkers,
+                    "all_docs"
+                ),
                 Callback({error, timeout}, Acc);
             {error, Error} ->
                 Callback({error, Error}, Acc)

--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -176,6 +176,16 @@ send_changes(DbName, ChangesArgs, Callback, PackedSeqs, AccIn, Timeout) ->
                 after
                     fabric_util:cleanup(Workers)
                 end;
+            {timeout, NewState} ->
+                DefunctWorkers = fabric_util:remove_done_workers(
+                    NewState#stream_acc.workers,
+                    waiting
+                ),
+                fabric_util:log_timeout(
+                    DefunctWorkers,
+                    "changes"
+                ),
+                throw({error, timeout});
             {error, Reason} ->
                 throw({error, Reason});
             Else ->

--- a/src/fabric_view_map.erl
+++ b/src/fabric_view_map.erl
@@ -41,7 +41,15 @@ go(DbName, DDoc, View, Args, Callback, Acc) ->
                 after
                     fabric_util:cleanup(Workers)
                 end;
-            {timeout, _} ->
+            {timeout, NewState} ->
+                DefunctWorkers = fabric_util:remove_done_workers(
+                    NewState#stream_acc.workers,
+                    waiting
+                ),
+                fabric_util:log_timeout(
+                    DefunctWorkers,
+                    "map_view"
+                ),
                 Callback({error, timeout}, Acc);
             {error, Error} ->
                 Callback({error, Error}, Acc)

--- a/src/fabric_view_reduce.erl
+++ b/src/fabric_view_reduce.erl
@@ -46,7 +46,15 @@ go(DbName, DDoc, VName, Args, Callback, Acc) ->
                 after
                     fabric_util:cleanup(Workers)
                 end;
-            {timeout, _} ->
+            {timeout, NewState} ->
+                DefunctWorkers = fabric_util:remove_done_workers(
+                    NewState#stream_acc.workers,
+                    waiting
+                ),
+                fabric_util:log_timeout(
+                    DefunctWorkers,
+                    "reduce_view"
+                ),
                 Callback({error, timeout}, Acc);
             {error, Error} ->
                 Callback({error, Error}, Acc)


### PR DESCRIPTION
Write a log line for each worker that did not return a response
when a fabric request times out. The format of the log line is:

```
fabric_worker_timeout ENDPOINT,NODE,SHARD_NAME
```

This is intented to be easily consumable by downstream tools
(e.g., Splunk).

BugzID: 26984

This patch can be tested by building dbcore using the latency_monkey branch of rexi [1], setting the appropriate config parameters and calling the appropriate fabric functions in a remsh [2].

[1] https://github.com/cloudant/rexi/tree/26984-latency-monkey

[2] https://gist.github.com/mikewallace1979/43db43c4506deff372e3
