### PR TITLE
Clear worker references for get_shard_replacements

### DIFF
--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -302,10 +302,11 @@ get_shards(DbName, #view_query_args{stale=Stale})
 get_shards(DbName, #view_query_args{stale=false}) ->
     mem3:shards(DbName).
 
-get_shard_replacements(DbName, UsedShards) ->
+get_shard_replacements(DbName, UsedShards0) ->
     % We only want to generate a replacements list from shards
     % that aren't already used.
     AllLiveShards = mem3:live_shards(DbName, [node() | nodes()]),
+    UsedShards = [S#shard{ref=undefined} || S <- UsedShards0],
     UnusedShards = AllLiveShards -- UsedShards,
 
     % If we have more than one copy of a range then we don't


### PR DESCRIPTION
This function relies on record equality. If a request passes workers
that have references defined it would return all copies of the shard
range incorrectly.

BugzId: 28992
