### PR TITLE
Set non-interactive default for set_security

### DIFF
--- a/src/fabric_rpc.erl
+++ b/src/fabric_rpc.erl
@@ -216,7 +216,13 @@ get_doc_count(DbName) ->
 get_update_seq(DbName) ->
     with_db(DbName, [], {couch_db, get_update_seq, []}).
 
-set_security(DbName, SecObj, Options) ->
+set_security(DbName, SecObj, Options0) ->
+    Options = case lists:keyfind(io_priority, 1, Options0) of
+        false ->
+            [{io_priority, {db_meta, security}}|Options0];
+        _ ->
+            Options0
+    end,
     with_db(DbName, Options, {couch_db, set_security, [SecObj]}).
 
 get_all_security(DbName, Options) ->

--- a/src/fabric_rpc2.erl
+++ b/src/fabric_rpc2.erl
@@ -273,7 +273,13 @@ get_update_seq(DbName) ->
 get_update_seq(DbName, Options) ->
     with_db(DbName, Options, {couch_db, get_update_seq, []}).
 
-set_security(DbName, SecObj, Options) ->
+set_security(DbName, SecObj, Options0) ->
+    Options = case lists:keyfind(io_priority, 1, Options0) of
+        false ->
+            [{io_priority, {db_meta, security}}|Options0];
+        _ ->
+            Options0
+    end,
     with_db(DbName, Options, {couch_db, set_security, [SecObj]}).
 
 get_all_security(DbName, Options) ->


### PR DESCRIPTION
Prior to this commit, a node would respect MM for clustered set_security
requests while still contributing to get_security requests. This would
lead to a situation where a user would change the security header for a
clustered DB, but the update would only reach a subset of the shards. On
subsequent requests, intermittant permission errors would be returned
due to security headers being inconsistent between shards.

BugzID: 28847
