### PR TITLE
Add admin_ctx function to fabric

### DIFF
--- a/src/fabric.erl
+++ b/src/fabric.erl
@@ -17,8 +17,6 @@
 -include_lib("mem3/include/mem3.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
--define(ADMIN_CTX, {user_ctx, #user_ctx{roles = [<<"_admin">>]}}).
-
 % DBs
 -export([all_dbs/0, all_dbs/1, create_db/1, create_db/2, delete_db/1,
     delete_db/2, get_db_info/1, get_doc_count/1, set_revs_limit/3,
@@ -123,13 +121,14 @@ set_revs_limit(DbName, Limit, Options) when is_integer(Limit), Limit > 0 ->
 %% @doc retrieves the maximum number of document revisions
 -spec get_revs_limit(dbname()) -> pos_integer() | no_return().
 get_revs_limit(DbName) ->
-    {ok, Db} = fabric_util:get_db(dbname(DbName), [?ADMIN_CTX]),
+    {ok, Db} = fabric_util:get_db(dbname(DbName), [fabric_util:admin_ctx()]),
     try couch_db:get_revs_limit(Db) after catch couch_db:close(Db) end.
 
 %% @doc sets the readers/writers/admin permissions for a database
 -spec set_security(dbname(), SecObj::json_obj()) -> ok.
 set_security(DbName, SecObj) ->
-    fabric_db_meta:set_security(dbname(DbName), SecObj, [?ADMIN_CTX]).
+    fabric_db_meta:set_security(dbname(DbName), SecObj,
+        [fabric_util:admin_ctx()]).
 
 %% @doc sets the readers/writers/admin permissions for a database
 -spec set_security(dbname(), SecObj::json_obj(), [option()]) -> ok.
@@ -137,7 +136,7 @@ set_security(DbName, SecObj, Options) ->
     fabric_db_meta:set_security(dbname(DbName), SecObj, opts(Options)).
 
 get_security(DbName) ->
-    get_security(DbName, [?ADMIN_CTX]).
+    get_security(DbName, [fabric_util:admin_ctx()]).
 
 %% @doc retrieve the security object for a database
 -spec get_security(dbname()) -> json_obj() | no_return().

--- a/src/fabric_db_meta.erl
+++ b/src/fabric_db_meta.erl
@@ -127,7 +127,7 @@ get_all_security(DbName, Options) ->
         Shards0 when is_list(Shards0) -> Shards0;
         _ -> mem3:shards(DbName)
     end,
-    Admin = [{user_ctx, #user_ctx{roles = [<<"_admin">>]}}],
+    Admin = [fabric_util:admin_ctx()],
     RexiMon = fabric_util:create_monitors(Shards),
     Workers = fabric_util:submit_jobs(Shards, get_all_security, [Admin]),
     Handler = fun handle_get_message/3,

--- a/src/fabric_doc_open.erl
+++ b/src/fabric_doc_open.erl
@@ -131,7 +131,7 @@ read_repair(#acc{dbname=DbName, replies=Replies}) ->
     [#doc{id = <<?LOCAL_DOC_PREFIX, _/binary>>} | _] ->
         choose_reply(Docs);
     [#doc{id=Id} | _] ->
-        Ctx = #user_ctx{roles=[<<"_admin">>]},
+        {user_ctx, Ctx} = fabric_util:admin_ctx(),
         Opts = [replicated_changes, {user_ctx, Ctx}],
         Res = fabric:update_docs(DbName, Docs, Opts),
         case Res of

--- a/src/fabric_doc_open_revs.erl
+++ b/src/fabric_doc_open_revs.erl
@@ -172,7 +172,7 @@ maybe_execute_read_repair(_Db, false) ->
     ok;
 maybe_execute_read_repair(Db, Docs) ->
     [#doc{id=Id} | _] = Docs,
-    Ctx = #user_ctx{roles=[<<"_admin">>]},
+    {user_ctx, Ctx} = fabric_util:admin_ctx(),
     Res = fabric:update_docs(Db, Docs, [replicated_changes, {user_ctx,Ctx}]),
     case Res of
         {ok, []} ->

--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -16,7 +16,7 @@
 
 -export([submit_jobs/3, submit_jobs/4, cleanup/1, recv/4, get_db/1, get_db/2, error_info/1,
         update_counter/3, remove_ancestors/2, create_monitors/1, kv/2,
-        remove_down_workers/2, doc_id_and_rev/1]).
+        remove_down_workers/2, doc_id_and_rev/1, admin_ctx/0]).
 -export([request_timeout/0, attachments_timeout/0, all_docs_timeout/0]).
 -export([stream_start/2, stream_start/4]).
 -export([log_timeout/2, remove_done_workers/2]).
@@ -312,3 +312,6 @@ kv(Item, Count) ->
 
 doc_id_and_rev(#doc{id=DocId, revs={RevNum, [RevHash|_]}}) ->
     {DocId, {RevNum, RevHash}}.
+
+admin_ctx() ->
+    {user_ctx, #user_ctx{roles = [<<"_admin">>]}}.


### PR DESCRIPTION
A convenience function `admin_ctx/0` added to `fabric_util`
to provide a single "source of truth" for admin's user context

BugzID: 12932