### PR TITLE
Add ability to gracefully terminate existing changes feeds

### DIFF
--- a/src/fabric.erl
+++ b/src/fabric.erl
@@ -32,7 +32,7 @@
 
 % Views
 -export([all_docs/4, changes/4, query_view/3, query_view/4, query_view/6,
-    get_view_group_info/2]).
+    get_view_group_info/2, end_changes/0]).
 
 % miscellany
 -export([design_docs/1, reset_validation_funs/1, cleanup_index_files/0,
@@ -333,6 +333,10 @@ query_view(DbName, Design, ViewName, Callback, Acc0, QueryArgs) ->
     ]}.
 get_view_group_info(DbName, DesignId) ->
     fabric_group_info:go(dbname(DbName), design_doc(DesignId)).
+
+-spec end_changes() -> ok.
+end_changes() ->
+    fabric_view_changes:increment_changes_epoch().
 
 %% @doc retrieve all the design docs from a database
 -spec design_docs(dbname()) -> {ok, [json_obj()]}.

--- a/src/fabric_view_changes.erl
+++ b/src/fabric_view_changes.erl
@@ -15,6 +15,7 @@
 -module(fabric_view_changes).
 
 -export([go/5, pack_seqs/1, unpack_seqs/2]).
+-export([increment_changes_epoch/0]).
 
 %% exported for upgrade purposes.
 -export([keep_sending_changes/8]).
@@ -39,6 +40,7 @@ go(DbName, Feed, Options, Callback, Acc0) when Feed == "continuous" orelse
         UpdateListener = {spawn_link(fabric_db_update_listener, go,
                                      [Parent, Ref, DbName, Timeout]),
                           Ref},
+        put(changes_epoch, get_changes_epoch()),
         try
             keep_sending_changes(
                 DbName,
@@ -88,8 +90,9 @@ keep_sending_changes(DbName, Args, Callback, Seqs, AccIn, Timeout, UpListen, T0)
     } = Collector,
     LastSeq = pack_seqs(NewSeqs),
     MaintenanceMode = config:get("cloudant", "maintenance_mode"),
+    NewEpoch = get_changes_epoch() > erlang:get(changes_epoch),
     if Limit > Limit2, Feed == "longpoll";
-      MaintenanceMode == "true"; MaintenanceMode == "nolb" ->
+      MaintenanceMode == "true"; MaintenanceMode == "nolb"; NewEpoch ->
         Callback({stop, LastSeq, pending_count(Offset)}, AccOut);
     true ->
         WaitForUpdate = wait_db_updated(UpListen),
@@ -460,6 +463,18 @@ validate_start_seq(DbName, Seq) ->
             Reason = <<"Malformed sequence supplied in 'since' parameter.">>,
             {error, {bad_request, Reason}}
     end.
+
+get_changes_epoch() ->
+    case application:get_env(fabric, changes_epoch) of
+        undefined ->
+            increment_changes_epoch(),
+            get_changes_epoch();
+        {ok, Epoch} ->
+            Epoch
+    end.
+
+increment_changes_epoch() ->
+    application:set_env(fabric, changes_epoch, os:timestamp()).
 
 unpack_seqs_test() ->
     meck:new(mem3),


### PR DESCRIPTION
Updating the changes_epoch config value will cause all current changes
feeds to gracefully exit without preventing new changes requests from
starting (unlike maintenance_mode).

BugzID: 45762