### PR TITLE
Added counter metric for fabric-worker-timeout.

### DIFF
--- a/priv/stat_descriptions.cfg
+++ b/priv/stat_descriptions.cfg
@@ -1,3 +1,7 @@
+{[fabric, worker, timeouts], [
+    {type, counter},
+    {desc, <<"number of worker timeouts">>}
+]}.
 {[fabric, read_repairs, success], [
     {type, counter},
     {desc, <<"number of successful read repair operations">>}

--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -154,6 +154,8 @@ timeout(Type, Default) ->
     end.
 
 log_timeout(Workers, EndPoint) ->
+    CounterKey = [fabric, worker, timeouts],
+    couch_stats:increment_counter(CounterKey),
     lists:map(fun(#shard{node=Dest, name=Name}) ->
         Fmt = "fabric_worker_timeout ~s,~p,~p",
         ?LOG_ERROR(Fmt, [EndPoint, Dest, Name])


### PR DESCRIPTION
This is being done as a good indicator for when mspot is
having issues.  An alert threshold will be set in
centinela.

BugzID: 50369