### PR TITLE
Add owner of shard to last_seq of changes query

### DIFF
--- a/src/fabric_rpc2.erl
+++ b/src/fabric_rpc2.erl
@@ -111,10 +111,10 @@ changes(DbName, Options, StartVector, DbOptions) ->
                 pending = couch_db:count_changes_since(Db, StartSeq),
                 epochs = get_epochs(Db)
             },
-            {ok, #cacc{seq=LastSeq, pending=Pending}} =
+            {ok, #cacc{seq=LastSeq, pending=Pending, epochs=Epochs}} =
                 couch_db:changes_since(Db, StartSeq, Enum, Opts, Acc0),
             rexi:stream_last({complete, [
-                {seq, {LastSeq, uuid(Db)}},
+                {seq, {LastSeq, uuid(Db), owner_of(LastSeq, Epochs)}},
                 {pending, Pending}
             ]})
         after


### PR DESCRIPTION
Prior to this commit, there was a bug where the response of a changes query would include epoch information for every change, but not for the last sequence. Subsequent shard changes queries would rewind from zero if the last_seq field was used in the clustered changes query and any shard had previously been moved.

BugzID: 58341