### PR TITLE
[backport] Check if db exists before creating

### DIFF
--- a/src/fabric_db_create.erl
+++ b/src/fabric_db_create.erl
@@ -26,14 +26,19 @@
 go(DbName, Options) ->
     case validate_dbname(DbName, Options) of
     ok ->
-        {Shards, Doc} = generate_shard_map(DbName, Options),
-        case {create_shard_files(Shards), create_shard_db_doc(Doc)} of
-        {ok, {ok, Status}} ->
-            Status;
-        {file_exists, {ok, _}} ->
+        case db_exists(DbName) of
+        true ->
             {error, file_exists};
-        {_, Error} ->
-            Error
+        false ->
+            {Shards, Doc} = generate_shard_map(DbName, Options),
+            case {create_shard_files(Shards), create_shard_db_doc(Doc)} of
+            {ok, {ok, Status}} ->
+                Status;
+            {file_exists, {ok, _}} ->
+                {error, file_exists};
+            {_, Error} ->
+                Error
+            end
         end;
     Error ->
         Error
@@ -167,3 +172,35 @@ make_document([#shard{dbname=DbName}|_] = Shards, Suffix) ->
         {<<"by_range">>, {[{K,lists:sort(V)} || {K,V} <- ByRangeOut]}}
     ]}}.
 
+db_exists(DbName) -> is_list(catch mem3:shards(DbName)).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+db_exists_for_existing_db_test() ->
+    start_meck_(),
+    Mock = fun(DbName) when is_binary(DbName) ->
+        [#shard{dbname = DbName, range = [0,100]}]
+    end,
+    ok = meck:expect(mem3, shards, Mock),
+    ?assertEqual(db_exists(<<"foobar">>), true),
+    ?assertEqual(meck:validate(mem3), true),
+    stop_meck_().
+
+db_exists_for_missing_db_test() ->
+    start_meck_(),
+    Mock = fun(DbName) ->
+        erlang:error(database_does_not_exist, DbName)
+    end,
+    ok = meck:expect(mem3, shards, Mock),
+    ?assertEqual(db_exists(<<"foobar">>), false),
+    ?assertEqual(meck:validate(mem3), false),
+    stop_meck_().
+
+start_meck_() ->
+    ok = meck:new(mem3).
+
+stop_meck_() ->
+    ok = meck:unload(mem3).
+
+-endif.


### PR DESCRIPTION
Should help with clients which always try to
create db (PUT /db), then handle a 412 response
if exists.

dbnext issue & pr:

 https://issues.apache.org/jira/browse/COUCHDB-2819

 https://github.com/cloudant/couchdb-fabric/commit/61fbb94b9f7f59c34483c092ecc39bd3a63155e2

BugzID: 59496
(Related to customer support ticket BugzID: 59106)

Style and unit tests kept same as dbnext.