### PR TITLE
Emit error row for a null doc id in POSTs to _all_docs

### DIFF
--- a/src/fabric.erl
+++ b/src/fabric.erl
@@ -419,10 +419,8 @@ name(Thing) ->
 
 docid(DocId) when is_list(DocId) ->
     list_to_binary(DocId);
-docid(DocId) when is_binary(DocId) ->
-    DocId;
 docid(DocId) ->
-    erlang:error({illegal_docid, DocId}).
+    DocId.
 
 docs(Docs) when is_list(Docs) ->
     [doc(D) || D <- Docs];


### PR DESCRIPTION
This is compatible behavior with CouchDB 1.x

BugzID: 68486
Jira: COUCHDB-3039